### PR TITLE
fixed calculation of [M-H] ions when only one anionic modification used

### DIFF
--- a/sugarMassesPredict.py
+++ b/sugarMassesPredict.py
@@ -782,7 +782,7 @@ if len(list(set(modifications).intersection(modifications_anionic))) >= 1:
         masses_anionic['nmod_anionic'] = masses_anionic[anionic_mod_used].sum(axis=1)
         masses_anionic['nmod_anionic'] = masses_anionic.nmod_anionic.astype(int)
     elif len(anionic_mod_used) == 1:
-        masses_anionic['nmod_anionic'] = 1
+        masses_anionic['nmod_anionic'] = masses_anionic[anionic_mod_used].astype(int)
     if "neg" in ESI_mode:
         ions = list(range(1, masses_anionic.nmod_anionic.max() + 1))
         ions = list("[M-" + pd.Series(ions).astype(str) + "H]-" + pd.Series(ions).astype(str))


### PR DESCRIPTION
fixed mistake in calculation of [M-H] ions when only one anionic modification is used. previously would only calculate [M-H] ion, and not [M-2H] etc. now works the same as for if multiple anionic modifications are ppresent i.e. will calculate [M-nH] ions where n is 1 to the maximum number of anionic groups on any oligo